### PR TITLE
Framerate is just a number

### DIFF
--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -46,7 +46,7 @@
             // make sure the numbers make sense
             if ( this.hours>23 || this.minutes>59 || this.seconds>59 || 
                  this.frames>=this.frameRate ||
-                 (this.dropFrame && this.seconds==0 && this.minutes%10 && this.frames<2*(this.frameRate/29.97) )
+                 (this.dropFrame && this.seconds==0 && this.minutes%10 && this.frames<2*(Math.floor(this.frameRate/29.97)) )
             ) throw new Error("Invalid timecode")
         }
         else if (typeof timeCode == 'object' && timeCode instanceof Date) {
@@ -82,7 +82,7 @@
         var fc = this.frameCount;
         // adjust for dropFrame
         if (this.dropFrame) {
-            var df = (this.frameRate==29.97 || this.frameRate==30000/10001) ? 2 : 4; // 59.94 skips 4 frames
+            var df = (this.frameRate==29.97 || this.frameRate==30000/1001) ? 2 : 4; // 59.94 skips 4 frames
             var d = Math.floor(this.frameCount / (17982*df/2));
             var m = this.frameCount % (17982*df/2);
             if (m<df) m=m+df;
@@ -103,7 +103,7 @@
         this.frameCount = (this.hours*3600 + this.minutes*60 + this.seconds) * Math.round(this.frameRate) + this.frames;
         if (this.dropFrame) {
             var totalMinutes = this.hours*60 + this.minutes;
-            var df = (this.frameRate==29.97 || this.frameRate==30000/10001) ? 2 : 4;
+            var df = (this.frameRate==29.97 || this.frameRate==30000/1001) ? 2 : 4;
             this.frameCount = this.frameCount - df * (totalMinutes - Math.floor(totalMinutes/10));
         }
     };

--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -19,13 +19,14 @@
         if (typeof frameRate == 'undefined') this.frameRate = 29.97;
         else if (typeof frameRate == 'number' && frameRate>0) this.frameRate = frameRate;
         else throw new Error('Number expected as framerate');
-        if (this.frameRate!=23.976 && this.frameRate!=24 && this.frameRate!=25 && this.frameRate!=29.97 && this.frameRate!=30 &&
-            this.frameRate!=50 && this.frameRate!=59.94 && this.frameRate!=60
-        ) throw new Error('Unsupported framerate');
+        // Framerate is just a number...
+        // if (this.frameRate!=23.976 && this.frameRate!=24 && this.frameRate!=25 && this.frameRate!=29.97 && this.frameRate!=30 &&
+        //     this.frameRate!=50 && this.frameRate!=59.94 && this.frameRate!=60000/1001 && this.frameRate!=60
+        // ) throw new Error('Unsupported framerate');
         
         // If we are passed dropFrame, we need to use it
         if (typeof dropFrame === 'boolean') this.dropFrame = dropFrame;
-        else this.dropFrame = (this.frameRate==29.97 || this.frameRate==59.94); // by default, assume DF for 29.97 and 59.94, NDF otherwise
+        else this.dropFrame = (this.frameRate==29.97 || this.frameRate==30000/1001 || this.frameRate==59.94 || this.frameRate==60000/1001); // by default, assume DF for 29.97 and 59.94, NDF otherwise
 
         // Now either get the frame count, string or datetime        
         if (typeof timeCode == 'number') {
@@ -60,7 +61,7 @@
         }
 
         // Make sure dropFrame is only for 29.97 & 59.94
-        if (this.dropFrame && this.frameRate!=29.97 && this.frameRate!=59.94) {
+        if (this.dropFrame && this.frameRate!=29.97 && this.frameRate!=30000/1001 && this.frameRate!=59.94 && this.frameRate!=60000/1001) {
             throw new Error('Drop frame is only supported for 29.97 and 59.94 fps');
         }
 
@@ -81,7 +82,7 @@
         var fc = this.frameCount;
         // adjust for dropFrame
         if (this.dropFrame) {
-            var df = this.frameRate==29.97 ? 2 : 4; // 59.94 skips 4 frames
+            var df = (this.frameRate==29.97 || this.frameRate==30000/10001) ? 2 : 4; // 59.94 skips 4 frames
             var d = Math.floor(this.frameCount / (17982*df/2));
             var m = this.frameCount % (17982*df/2);
             if (m<df) m=m+df;
@@ -102,7 +103,7 @@
         this.frameCount = (this.hours*3600 + this.minutes*60 + this.seconds) * Math.round(this.frameRate) + this.frames;
         if (this.dropFrame) {
             var totalMinutes = this.hours*60 + this.minutes;
-            var df = this.frameRate == 29.97 ? 2 : 4;
+            var df = (this.frameRate==29.97 || this.frameRate==30000/10001) ? 2 : 4;
             this.frameCount = this.frameCount - df * (totalMinutes - Math.floor(totalMinutes/10));
         }
     };

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -89,6 +89,25 @@ describe('Constructor tests', function(){
         expect(Timecode(1078920*2,59.94,true).toString()).to.be('10:00:00;00'); 
         expect(Timecode(3597*2+1,59.94,true).toString()).to.be('00:01:59;59'); 
     });
+    it ('drop-frame counts (exact framerate)', function() {
+        expect(Timecode('00:10:00;00',30000/1001).frameCount).to.be(17982);
+        expect(Timecode('00:10:00;00',60000/1001).frameCount).to.be(17982*2);
+        expect(Timecode('10:00:00;00',30000/1001).frameCount).to.be(1078920);
+        expect(Timecode('10:00:00;00',60000/1001).frameCount).to.be(1078920*2);
+        expect(function(){Timecode('00:02:00;00',30000/1001)}).to.throwError();
+        expect(function(){Timecode('00:02:00;02',30000/1001)}).to.not.throwError();
+        expect(function(){Timecode('00:02:00;00',60000/1001)}).to.throwError();
+        expect(function(){Timecode('00:02:00;02',60000/1001)}).to.throwError();
+        expect(function(){Timecode('00:02:00;04',60000/1001)}).to.not.throwError();
+        expect(Timecode('00:01:59;29',30000/1001).frameCount).to.be(3597);
+        expect(Timecode('00:01:59;59',60000/1001).frameCount).to.be(3597*2+1);
+        expect(Timecode(17982,30000/1001,true).toString()).to.be('00:10:00;00'); 
+        expect(Timecode(1078920,30000/1001,true).toString()).to.be('10:00:00;00'); 
+        expect(Timecode(3597,30000/1001,true).toString()).to.be('00:01:59;29'); 
+        expect(Timecode(17982*2,60000/1001,true).toString()).to.be('00:10:00;00'); 
+        expect(Timecode(1078920*2,60000/1001,true).toString()).to.be('10:00:00;00'); 
+        expect(Timecode(3597*2+1,60000/1001,true).toString()).to.be('00:01:59;59');
+    });
     it ('non-drop-frame counts', function() {
         expect(Timecode('00:10:00:00',25).frameCount).to.be(15000);
         expect(Timecode('10:00:00:00',25).frameCount).to.be(900000);

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -20,7 +20,7 @@ describe('Constructor tests', function(){
 
     it ('incorrect initializers throw', function() {
         expect(function(){Timecode(1,-1)}).to.throwException();
-        expect(function(){Timecode(1,66)}).to.throwException();
+        // expect(function(){Timecode(1,66)}).to.throwException();
         expect(function(){Timecode('dewdew');}).to.throwException();
         expect(function(){Timecode('dewdew');}).to.throwException();
         expect(function(){Timecode({w:3});}).to.throwException();
@@ -57,13 +57,17 @@ describe('Constructor tests', function(){
         expect(Timecode(1).dropFrame).to.be(true);
         expect(Timecode(1).frameRate).to.be(29.97);
         expect(Timecode(1,29.97).dropFrame).to.be(true);
+        expect(Timecode(1,30000/1001).dropFrame).to.be(true);
         expect(Timecode(1,59.94).dropFrame).to.be(true);
+        expect(Timecode(1,60000/1001).dropFrame).to.be(true);
         expect(Timecode(1,25).dropFrame).to.be(false);
     });
 
     it ('drop-frame only for 29.97 and 59.94', function() {
         expect(function(){Timecode(0,30,true)}).to.throwException();
         expect(function(){Timecode(0,59.94,true)}).to.not.throwException();
+        expect(function(){Timecode(0,30000/1001,true)}).to.not.throwException();
+        expect(function(){Timecode(0,60000/1001,true)}).to.not.throwException();
     });
 
     it ('drop-frame counts', function() {


### PR DESCRIPTION
Allow specification of "exact" framerates (e.g., 30000/1001, 30/1.001, etc) in place of rounded framerates (29.97) so that timecodes don't drift.